### PR TITLE
Interval Struct for determining intervals in structured streams

### DIFF
--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stream"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/stream/src/time.rs
+++ b/stream/src/time.rs
@@ -87,7 +87,7 @@ impl Sub<u64> for Time {
 
     fn sub(self, other: u64) -> Time {
         Time {
-            val: self.val + other,
+            val: self.val - other,
         }
     }
 }
@@ -156,7 +156,7 @@ impl PartialOrd for Interval {
 
 impl ToString for Interval {
     fn to_string(&self) -> String {
-        format!("{:?}-{:?}", self.start, self.end) // Note:might want to convert ms since UNIX EPOCH to human readable time
+        format!("{:}-{:}", self.start.to_string(), self.end.to_string()) // Note:might want to convert ms since UNIX EPOCH to human readable time
     }
 }
 
@@ -253,6 +253,68 @@ mod tests {
         }
     }
 
+    macro_rules! time_add {
+        ($($name:ident: $value:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (this, that, expected) = $value;
+                    assert!(this + that == expected);
+                }
+            )*
+        };
+    }
+
+    macro_rules! time_sub {
+        ($($name:ident: $value:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (this, that, expected) = $value;
+                    assert!(this - that == expected);
+                }
+            )*
+        };
+    }
+
+    macro_rules! time_to_string {
+        ($($name:ident: $value:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (this, expected) = $value;
+                    assert!(this.to_string() == expected);
+                }
+            )*
+        };
+    }
+
+    // FIXME: this should try and test intervals using ::new()
+    macro_rules! interval_add {
+        ($($name:ident: $value:expr,)*) => {
+            $(
+                #[test]
+                fn $name(){
+                    let (this, that, expected) = $value;
+                    assert!(this + that == expected);
+                }
+            )*
+        };
+    }
+
+    //FIXME: this should try and test intervals using ::new()
+    macro_rules! interval_sub {
+        ($($name:ident: $value:expr,)*) => {
+            $(
+                #[test]
+                fn $name(){
+                    let (this, that, expected) = $value;
+                    assert!(this - that == expected);
+                }
+            )*
+        };
+    }
+
     #[test]
     fn test_constructor_time() {
         assert_eq!(Time { val: 0 }.val, 0);
@@ -278,6 +340,16 @@ mod tests {
         println!("{:?}", cur_interval.start);
         assert!((cur_time.as_millis() as u64) <= cur_interval.start.val);
         assert!(cur_interval.end >= Time::new(cur_time.as_millis() as u64) + offset);
+    }
+
+    time_to_string! {
+        test_to_string_time_zero: (Time::new(0), "0"),
+        test_to_string_time_one: (Time::new(1), "1"),
+        test_to_string_time_max: (Time::new(std::u64::MAX), "18446744073709551615"),
+    }
+
+    time_to_string! {
+        it_to_string_interval : (Interval{start: Time::new(0), end: Time::new(4)}, "0-4"),
     }
 
     time_partial_eq! {
@@ -335,5 +407,23 @@ mod tests {
     time_until! {
         until_lt : (Time::new(0), Time::new(4), Time::new(4)),
         until_gt : (Time::new(12), Time::new(200000), Time::new(199988)),
+    }
+
+    time_add! {
+        add_int : (Time::new(4), 2, Time::new(6)),
+        add_time : (Time::new(4), Time::new(2), Time::new(6)),
+    }
+
+    time_sub! {
+        sub_int : (Time::new(4), 2, Time::new(2)),
+        sub_time : (Time::new(4), Time::new(2), Time::new(2)),
+    }
+
+    interval_add! {
+        it_add : (Interval{start : Time::new(0), end : Time::new(4)}, Interval{start : Time::new(0), end : Time::new(2)}, Interval{start: Time::new(0), end : Time::new(6)}),
+    }
+
+    interval_sub! {
+        it_sub : (Interval{start : Time::new(0), end : Time::new(4)}, Interval{start : Time::new(0), end : Time::new(2)}, Interval{start: Time::new(0), end : Time::new(2)}),
     }
 }

--- a/stream/src/time.rs
+++ b/stream/src/time.rs
@@ -6,6 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// This is a simple class that represents an absolute instant of time.
 /// Internally, it represents time as the difference, measured in milliseconds, between the current
 /// time and midnight, January 1, 1970 UTC.
+#[derive(Debug, Clone)]
 pub struct Time {
     val: u64,
 }
@@ -92,7 +93,7 @@ impl Interval {
             .expect("Time went backwards");
         let cur_time = Time::new(cur_time.as_millis() as u64);
         Interval {
-            start: cur_time,
+            start: cur_time.clone(),
             end: cur_time + duration,
         }
     }
@@ -128,7 +129,7 @@ impl PartialEq for Interval {
 
 impl ToString for Interval {
     fn to_string(&self) -> String {
-        format!("{}-{}", self.start, self.end)
+        format!("{:?}-{:?}", self.start, self.end) // Note:might want to convert ms since UNIX EPOCH to human readable time
     }
 }
 
@@ -226,21 +227,30 @@ mod tests {
     }
 
     #[test]
-    fn test_constructor_Time() {
+    fn test_constructor_time() {
         assert_eq!(Time { val: 0 }.val, 0);
         assert_eq!(Time::new(0).val, 0);
     }
 
     #[test]
-    fn test_constructor_Interval {
-        assert_eq!(Interval { start: 0, end: 0 }.start, 0);
+    fn test_constructor_interval() {
+        assert_eq!(
+            Interval {
+                start: Time::new(0),
+                end: Time::new(0)
+            }
+            .start,
+            Time::new(0)
+        );
         let cur_time = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards");
         let offset = Time::new(1000000);
-        let curInterval = Interval::new(offset);
-        assert!(cur_time as u64 < curInterval.start.val);
-        assert!(cur_time + (cur_time+offset).val);
+        let cur_interval = Interval::new(offset.clone());
+        println!("{:?}", cur_time.as_millis() as u64);
+        println!("{:?}", cur_interval.start);
+        assert!((cur_time.as_millis() as u64) <= cur_interval.start.val);
+        assert!(cur_interval.end >= Time::new(cur_time.as_millis() as u64) + offset);
     }
 
     time_partial_eq! {

--- a/stream/src/time.rs
+++ b/stream/src/time.rs
@@ -315,7 +315,6 @@ mod tests {
         it_comp_nlt : (Interval::new(4), Interval::new(0), std::cmp::Ordering::Less, false),
         it_comp_gt : (Interval::new(4), Interval::new(0), std::cmp::Ordering::Greater, true),
         it_comp_ngt : (Interval::new(0), Interval::new(4), std::cmp::Ordering::Greater, false),
-        it_comp_eq : (Interval::new(4), Interval::new(4), std::cmp::Ordering::Equal, true),
     }
 
     time_is_multiple! {


### PR DESCRIPTION
- The `Interval` struct measures intervals using UNIX epoch standard time in conjunction with the standard operators included with our basic `Time` implementation
- Changed access modifiers for `Interval` and `Time` to be public
- Changed Rust edition from stable 2021 edition back to 2018 for better compatibility (decision subject to change)